### PR TITLE
modify(): Add CategoryUpdateRequestVO and update category endpoint to…

### DIFF
--- a/src/main/java/kh/com/eco/service/category/controller/vo/request/CategoryUpdateRequestVO.java
+++ b/src/main/java/kh/com/eco/service/category/controller/vo/request/CategoryUpdateRequestVO.java
@@ -1,0 +1,11 @@
+package kh.com.eco.service.category.controller.vo.request;
+
+import lombok.Data;
+
+@Data
+public class CategoryUpdateRequestVO {
+	private String name;
+	private String author;
+	private Integer shares;
+	private Long posts;
+}

--- a/src/main/java/kh/com/eco/service/category/controller/web/CategoryController.java
+++ b/src/main/java/kh/com/eco/service/category/controller/web/CategoryController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kh.com.eco.service.category.controller.vo.request.BatchCreateRequestVO;
 import kh.com.eco.service.category.controller.vo.request.CategoryCreateRequestVO;
+import kh.com.eco.service.category.controller.vo.request.CategoryUpdateRequestVO;
 import kh.com.eco.service.category.controller.vo.response.CategoryResponseVO;
 import kh.com.eco.service.category.dto.request.BatchCreateRequestDTO;
 import kh.com.eco.service.category.dto.request.CategoryCreateRequestDTO;
@@ -50,7 +51,7 @@ public class CategoryController {
 	@Operation(method = "update", summary = "Update a category", description = "Update an existing category by its ID.")
 	@PostMapping("/{categoryId}")
 	public ResponseMessageBuilder.ResponseMessage<Void> updateCategory(@PathVariable Long categoryId,
-	                                                                   @RequestBody @Valid CategoryCreateRequestVO request) {
+	                                                                   @RequestBody CategoryUpdateRequestVO request) {
 		this.service.updateCategory(categoryId, mapper.convertValue(request, CategoryCreateRequestDTO.class));
 		return new ResponseMessageBuilder<Void>().success().build();
 	}


### PR DESCRIPTION
This pull request introduces a new `CategoryUpdateRequestVO` class to streamline the handling of category updates and modifies the `CategoryController` to use this new class in the `updateCategory` method. These changes improve code clarity and maintainability by separating update-specific logic from creation-specific logic.

### New class for category updates:

* [`src/main/java/kh/com/eco/service/category/controller/vo/request/CategoryUpdateRequestVO.java`](diffhunk://#diff-54c4cd9afff32b59f685fdeb63811522b99f2a270bf4f0588aaf352b2dbc3ebcR1-R11): Introduced the `CategoryUpdateRequestVO` class with fields `name`, `author`, `shares`, and `posts` to encapsulate data for category updates.

### Controller updates:

* [`src/main/java/kh/com/eco/service/category/controller/web/CategoryController.java`](diffhunk://#diff-aff9decc08dbd4fa408bd8d2308aeae729099f2e85a1d866b57764e84d5fd97dR8): Added import for the new `CategoryUpdateRequestVO` class.
* [`src/main/java/kh/com/eco/service/category/controller/web/CategoryController.java`](diffhunk://#diff-aff9decc08dbd4fa408bd8d2308aeae729099f2e85a1d866b57764e84d5fd97dL53-R54): Updated the `updateCategory` method to use `CategoryUpdateRequestVO` instead of `CategoryCreateRequestVO`, ensuring better alignment with update-specific requirements.… use new request object